### PR TITLE
Fix CumulativeSum API and printvec macro

### DIFF
--- a/src/cumulative_sum.rs
+++ b/src/cumulative_sum.rs
@@ -23,7 +23,8 @@ impl<T> CumulativeSum<T>
 where
     T: Add<Output = T> + Sub<Output = T> + Copy + Default,
 {
-    fn new(arr: &[T]) -> Self {
+    /// Creates a new cumulative sum from a slice.
+    pub fn new(arr: &[T]) -> Self {
         let mut data = Vec::with_capacity(arr.len() + 1);
         data.push(T::default());
 
@@ -35,7 +36,8 @@ where
         Self { data }
     }
 
-    fn sum(&self, l: usize, r: usize) -> T {
+    /// Returns the inclusive sum on the range [l, r).
+    pub fn sum(&self, l: usize, r: usize) -> T {
         assert!(l <= r && r < self.data.len());
         self.data[r] - self.data[l]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod cumulative_sum;
 pub mod utils;
 
 pub use union_find::UnionFind;
+pub use cumulative_sum::CumulativeSum;

--- a/src/macro_utils.rs
+++ b/src/macro_utils.rs
@@ -22,9 +22,14 @@ macro_rules! println {
 
 #[macro_export]
 macro_rules! printvec {
-    ($vec:expr) => {
-        println!("{}", $vec.iter().join(" "));
-    };
+    ($vec:expr) => {{
+        let joined = $vec
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        println!("{}", joined);
+    }};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- expose `CumulativeSum::new` and `CumulativeSum::sum`
- re-export `CumulativeSum` in `lib.rs`
- fix `printvec!` macro so it doesn't rely on `itertools`

## Testing
- `cargo test`
- `cargo fmt` *(fails: `rustfmt` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845a53b92a883319c7d9e3d99793cc6