### PR TITLE
Implement 2D cumulative sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A collection of useful macros and data structures for competitive programming in
 
 - **Data Structures**
   - `UnionFind`: Efficient Union-Find/Disjoint Set Union data structure
+  - `CumulativeSum`: 1D prefix sums for range queries
+  - `CumulativeSum2D`: 2D prefix sums for rectangular queries
 
 ## Usage
 
@@ -44,6 +46,21 @@ fn main() {
     
     println!("Same set:", uf.same(0, 1));  // true
     println!("Set size:", uf.size(0));     // 2
+}
+```
+
+### 2D Cumulative Sum
+
+```rust
+use rust_macro::CumulativeSum2D;
+
+fn main() {
+    let matrix = vec![
+        vec![1, 2],
+        vec![3, 4],
+    ];
+    let cs = CumulativeSum2D::new(&matrix);
+    println!("{}", cs.sum(0, 0, 2, 2)); // 10
 }
 ```
 

--- a/src/cumulative_sum_2d.rs
+++ b/src/cumulative_sum_2d.rs
@@ -1,0 +1,60 @@
+#![allow(
+    non_snake_case,
+    unused_variables,
+    unused_assignments,
+    unused_mut,
+    unused_imports,
+    unused_macros,
+    dead_code
+)]
+
+use std::ops::{Add, Sub};
+
+#[derive(Debug, Clone)]
+pub struct CumulativeSum2D<T>
+where
+    T: Add<Output = T> + Sub<Output = T> + Copy + Default,
+{
+    data: Vec<Vec<T>>, // (n+1) x (m+1) prefix sums
+}
+
+impl<T> CumulativeSum2D<T>
+where
+    T: Add<Output = T> + Sub<Output = T> + Copy + Default,
+{
+    /// Creates a new 2D cumulative sum from a matrix slice.
+    pub fn new(matrix: &[Vec<T>]) -> Self {
+        let n = matrix.len();
+        let m = if n > 0 { matrix[0].len() } else { 0 };
+        let mut data = vec![vec![T::default(); m + 1]; n + 1];
+        for i in 0..n {
+            for j in 0..m {
+                data[i + 1][j + 1] = data[i + 1][j] + data[i][j + 1] - data[i][j] + matrix[i][j];
+            }
+        }
+        Self { data }
+    }
+
+    /// Returns the sum on the rectangle [x1, x2) x [y1, y2).
+    pub fn sum(&self, x1: usize, y1: usize, x2: usize, y2: usize) -> T {
+        assert!(x1 <= x2 && y1 <= y2);
+        assert!(x2 < self.data.len() && y2 < self.data[0].len());
+        self.data[x2][y2] - self.data[x1][y2] - self.data[x2][y1] + self.data[x1][y1]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cumulative_sum_2d() {
+        let matrix = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+        let cum = CumulativeSum2D::new(&matrix);
+
+        assert_eq!(cum.sum(0, 0, 1, 1), 1); // single element
+        assert_eq!(cum.sum(0, 0, 2, 2), 12); // top-left 2x2 block
+        assert_eq!(cum.sum(1, 1, 3, 3), 28); // bottom-right 2x2 block
+        assert_eq!(cum.sum(0, 0, 3, 3), 45); // whole matrix
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 //! A collection of useful utilities for competitive programming in Rust
 
-pub mod union_find;
-pub mod macro_utils;
 pub mod cumulative_sum;
+pub mod cumulative_sum_2d;
+pub mod macro_utils;
+pub mod union_find;
 pub mod utils;
 
-pub use union_find::UnionFind;
 pub use cumulative_sum::CumulativeSum;
+pub use cumulative_sum_2d::CumulativeSum2D;
+pub use union_find::UnionFind;


### PR DESCRIPTION
## Summary
- add new `CumulativeSum2D` structure for 2D prefix sums
- expose the new structure from the library
- document the new data structure and provide usage example

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68465eaba9b48331a2cea02c11b22b7d