### PR TITLE
Fix trailing spaces and apply formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,27 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: Set up Rust
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         override: true
-        
+
     - name: Cache cargo registry
       uses: actions/cache@v3
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-        
+
     - name: Cache cargo build
       uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-        
+
     - name: Build
       run: cargo build --verbose
-      
+
     - name: Run tests
       run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ use rust_macro::UnionFind;
 
 fn main() {
     let mut uf = UnionFind::new(5);
-    
+
     uf.unite(0, 1);
     uf.unite(2, 3);
-    
+
     println!("Same set:", uf.same(0, 1));  // true
     println!("Set size:", uf.size(0));     // 2
 }

--- a/src/cumulative_sum.rs
+++ b/src/cumulative_sum.rs
@@ -8,8 +8,8 @@
     dead_code
 )]
 
-use std::{cmp::max, cmp::min, collections::HashMap, collections::HashSet, io::*};
 use std::ops::{Add, Sub};
+use std::{cmp::max, cmp::min, collections::HashMap, collections::HashSet, io::*};
 
 #[derive(Debug, Clone)]
 pub struct CumulativeSum<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! A collection of useful utilities for competitive programming in Rust
 
-pub mod union_find;
-pub mod macro_utils;
 pub mod cumulative_sum;
+pub mod macro_utils;
+pub mod union_find;
 pub mod utils;
 
 pub use union_find::UnionFind;

--- a/src/union_find.rs
+++ b/src/union_find.rs
@@ -30,11 +30,11 @@ impl UnionFind {
     pub fn unite(&mut self, x: usize, y: usize) {
         let x_root = self.find(x);
         let y_root = self.find(y);
-        
+
         if x_root == y_root {
             return;
         }
-        
+
         // Union by size
         if self.size[x_root] < self.size[y_root] {
             self.parent[x_root] = y_root;
@@ -64,22 +64,22 @@ mod tests {
     #[test]
     fn test_union_find() {
         let mut uf = UnionFind::new(5);
-        
+
         // Initial state
         assert!(uf.same(0, 0));
         assert!(!uf.same(0, 1));
-        
+
         // Union operations
         uf.unite(0, 1);
         assert!(uf.same(0, 1));
-        
+
         uf.unite(2, 3);
         assert!(uf.same(2, 3));
         assert!(!uf.same(1, 2));
-        
+
         uf.unite(1, 2);
         assert!(uf.same(0, 3));
-        
+
         // Check size
         assert_eq!(uf.size(0), 4);
     }


### PR DESCRIPTION
## Summary
- remove trailing spaces from README example
- clean up union_find.rs trailing spaces
- trim YAML workflow lines
- run `cargo fmt` for consistent style

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68465e3d5a54833195d02090d5883d35